### PR TITLE
Add support for specifying a type for `env` type configuration values…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-lib/compare/1.23.0...HEAD
 
+### Added
+
+* Configuration now supports providing a type to convert Environment Variables
+  to a provided type. Addressing the issue [here](https://github.com/chaostoolkit/chaostoolkit/issues/254#issue-1062797767)
+  To specifically convert an Environment Variable loaded into configuration to
+  a type, provide the `env_var_type` key in the same block as the "env" declaration.
+  Supported values are: `str, int, float, bytes`.
+
 ## [1.23.0][] - 2021-11-05
 
 

--- a/chaoslib/__init__.py
+++ b/chaoslib/__init__.py
@@ -268,16 +268,7 @@ def convert_vars(value: List[str]) -> Dict[str, Any]:  # noqa: C901
             if ":" in k:
                 k, typ = k.rsplit(":", 1)
                 try:
-                    if typ == "str":
-                        pass
-                    elif typ == "int":
-                        v = int(v)
-                    elif typ == "float":
-                        v = float(v)
-                    elif typ == "bytes":
-                        v = v.encode("utf-8")
-                    else:
-                        raise ValueError("var supports only: str, int, float and bytes")
+                    v = convert_to_type(typ, v)
                 except (TypeError, UnicodeEncodeError):
                     raise ValueError("var cannot convert value to required type")
             var[k] = v
@@ -287,6 +278,28 @@ def convert_vars(value: List[str]) -> Dict[str, Any]:  # noqa: C901
             raise ValueError("var needs to be in the format name[:type]=value")
 
     return var
+
+
+def convert_to_type(type: str, val: str) -> Union[str, int, float, bytes]:
+    """
+    Converts a value to a provided type. If `type` is None, then the original string is
+    returned, else the val is coerced into the provided type. An exception is thrown
+    if the type is not supported.
+
+    :param type: str representing what type to convert `val` to
+    :param val: str representing the variable loaded in to configuration
+    :returns: Union[str, int, float, bytes] representing the converted value
+    """
+    if type is None or type == "str":
+        return val
+    elif type == "int":
+        return int(val)
+    elif type == "float":
+        return float(val)
+    elif type == "bytes":
+        return val.encode("utf-8")
+    else:
+        raise ValueError("variables can only be: str, int, float, or bytes")
 
 
 class PayloadEncoder(JSONEncoder):

--- a/chaoslib/configuration.py
+++ b/chaoslib/configuration.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 from logzero import logger
 
+from chaoslib import convert_to_type
 from chaoslib.exceptions import InvalidExperiment
 from chaoslib.types import Configuration
 
@@ -35,6 +36,11 @@ def load_configuration(
             "type": "env",
             "key": "HOSTNAME",
             "default": "localhost"
+        },
+        "port": {
+            "type": "env",
+            "key": "SERVICE_PORT",
+            "env_var_type": "int"
         }
     }
     ```
@@ -43,7 +49,9 @@ def load_configuration(
     configuration key is dynamically fetched from the `MY_TOKEN` environment
     variable. The `host` configuration key is dynamically fetched from the
     `HOSTNAME` environment variable, but if not defined, the default value
-    `localhost` will be used instead.
+    `localhost` will be used instead. The `port` configuration key is dynamically
+    fetched from the `SERVICE_PORT` environment variable. It is coerced into an `int`
+    with the addition of the `env_var_type` key.
 
     When `extra_vars` is provided, it must be a dictionnary where keys map
     to configuration key. The values from `extra_vars` always override the
@@ -70,7 +78,11 @@ def load_configuration(
                         "Configuration makes reference to an environment key"
                         " that does not exist: {}".format(env_key)
                     )
-                conf[key] = extra_vars.get(key, env.get(env_key, env_default))
+                env_var_type = value.get("env_var_type")
+                env_var_value = convert_to_type(
+                    env_var_type, env.get(env_key, env_default)
+                )
+                conf[key] = extra_vars.get(key, env_var_value)
         else:
             conf[key] = extra_vars.get(key, value)
 


### PR DESCRIPTION
… (#248)

Signed-off-by: Ciaran Evans <ciaran@reliably.com>